### PR TITLE
Handle combined additional attributes

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,5 @@
 [mypy]
+files = hls_vi
 strict = True
 pretty = True
 show_error_codes = True

--- a/tests/fixtures/HLS-VI.S30.T13RCN.2024128T173909.v2.0.cmr.xml
+++ b/tests/fixtures/HLS-VI.S30.T13RCN.2024128T173909.v2.0.cmr.xml
@@ -287,7 +287,7 @@
     <AdditionalAttribute>
       <Name>PROCESSING_BASELINE</Name>
       <Values>
-        <Value>05.10</Value>
+        <Value>05.11</Value>
       </Values>
     </AdditionalAttribute>
     <AdditionalAttribute>

--- a/tests/fixtures/HLS.S30.T13RCN.2024128T173909.v2.0/HLS.S30.T13RCN.2024128T173909.v2.0.cmr.xml
+++ b/tests/fixtures/HLS.S30.T13RCN.2024128T173909.v2.0/HLS.S30.T13RCN.2024128T173909.v2.0.cmr.xml
@@ -288,7 +288,7 @@
     <AdditionalAttribute>
       <Name>PROCESSING_BASELINE</Name>
       <Values>
-        <Value>05.10</Value>
+        <Value>05.11 + 05.11</Value>
       </Values>
     </AdditionalAttribute>
     <AdditionalAttribute>

--- a/tox.ini
+++ b/tox.ini
@@ -20,5 +20,5 @@ extras =
   test
 commands =
   flake8
-  mypy hls_vi
+  mypy
   pytest -vv --doctest-modules


### PR DESCRIPTION
When an additional attribute in the metadata is a result of combining metadata from a split granule, it results in an attribute value that is a combination of the separate metadata, where the 2 separate values are joined with `" + "`. In this case set the attribute value to the value preceding the `" + "`.

This avoids CMR parsing errors resulting from data type constraints (defined at the collection level) placed upon the additional attribute values.