### PR TITLE
chore: Bump setup.py pkg version to v1.16

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="hls_vi",
-    version="1.12",
+    version="1.16",
     packages=["hls_vi"],
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
This PR bumps the definition of the package version in `setup.py` to match the tag that I'll create as part of releasing the last merged PR (#48)

I don't think this is strictly needed but would be nice to keep consistent