### PR TITLE
Drop deprecated ubuntu-20.04 GitHub Actions runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [push, workflow_dispatch]
 
 jobs:
   tox_in_docker:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout sources


### PR DESCRIPTION
Address Action Annotation warning:

[tox_in_docker](https://github.com/NASA-IMPACT/hls-vi/actions/runs/13859426346/job/38783929021)
The Ubuntu-20.04 brownout takes place from 2025-02-01. For more details, see https://github.com/actions/runner-images/issues/11101