### PR TITLE
Install dataclasses only for python pre-3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     packages=["hls_vi"],
     include_package_data=True,
     install_requires=[
-        "dataclasses",
+        "dataclasses;python_version<'3.7'",
         "geojson",
         "importlib_resources",
         "lxml>=3.6.0,<6",


### PR DESCRIPTION
Constrain the dataclasses dependency such that it is installed _only_ for python <3.7 since the dependency is only a backport prior to 3.7. Otherwise, the backport library can cause problems when used in later versions of python, such as a confusing/misleading error message like "module 'typing' has no attribute '_ClassVar'", which I saw while working on the hls-vi-historical image.